### PR TITLE
Various fixes (important: making the RNN non-trivial)

### DIFF
--- a/elman_rnn/Elman_RNN.py
+++ b/elman_rnn/Elman_RNN.py
@@ -9,15 +9,16 @@ torch.manual_seed(1)
 
 dtype = torch.FloatTensor
 input_size, hidden_size, output_size = 7, 6, 1
-epochs = 200
+epochs = 3000
 seq_length = 20
-lr = 0.1
+lr = 0.01
 
 data_time_steps = np.linspace(2, 10, seq_length + 1)
 data = np.sin(data_time_steps)
 data.resize((seq_length + 1, 1))
+data_time_steps.resize((seq_length + 1, 1))
 
-x = Variable(torch.Tensor(data[:-1]).type(dtype), requires_grad=False)
+x = Variable(torch.Tensor(data_time_steps[:-1]).type(dtype), requires_grad=False)
 y = Variable(torch.Tensor(data[1:]).type(dtype), requires_grad=False)
 
 w1 = torch.FloatTensor(input_size, hidden_size).type(dtype)
@@ -27,7 +28,7 @@ w2 = torch.FloatTensor(hidden_size, output_size).type(dtype)
 init.normal(w2, 0.0, 0.3)
 w2 = Variable(w2, requires_grad=True)
 
-def forward(x,context_state, w1, w2):
+def forward(input, context_state, w1, w2):
   xh = torch.cat((input, context_state), 1)
   context_state = torch.tanh(xh.mm(w1))
   out = context_state.mm(w2)
@@ -39,7 +40,7 @@ for i in range(epochs):
   for j in range(x.size(0)):
     input = x[j:(j+1)]
     target = y[j:(j+1)]
-    (pred, context_state) = forward(x, context_state, w1, w2)
+    (pred, context_state) = forward(input, context_state, w1, w2)
     loss = (pred - target).pow(2).sum()/2
     total_loss += loss
     loss.backward()
@@ -48,7 +49,7 @@ for i in range(epochs):
     w1.grad.data.zero_()
     w2.grad.data.zero_()
     context_state = Variable(context_state.data)
-  if i % 10 == 0:
+  if i % 100 == 0:
      print("Epoch: {} loss {}".format(i, total_loss.data[0]))
 
 
@@ -62,8 +63,8 @@ for i in range(x.size(0)):
   predictions.append(pred.data.numpy().ravel()[0])
 
 
-pl.scatter(data_time_steps[:-1], x.data.numpy(), s=90, label="Actual")
-pl.scatter(data_time_steps[1:], predictions, label="Predicted")
+pl.scatter(data_time_steps[:-1], y.data.numpy(), s=90, label="Actual")
+pl.scatter(data_time_steps[:-1], predictions, label="Predicted")
 pl.legend()
 pl.show()
 


### PR DESCRIPTION
Hi,

I saw your post on HN, and been meaning to take some time to learn NNs for some time now. I found your post really useful, but I found some (one of which is quite serious) issues. Thanks for the post, and hope you find these fixes useful.

/ Johan

The first issue was that `x` was defined as a part of `data` not
`data_time_steps`. This means during training you are training the RNN to:
"Given sine-function values, return sine-function values". This means that all
the RNN does it to become an identity operation. So this corrects that error.

This however makes the convergence aweful. Keeping the `lr` makes the `loss`
oscillate around a value close to `2.0`. Hence, it stops approaching an
optimised value. So I lowered the learning rate by a factor of ten. It now
converges quite well, but slow, so I also increased the `epochs` by a factor
of ten. Now it converges on reasonable values. (and to not print too much, I
changed the printing to occur 10 times less fequently as well)

Before, `x` had the sine-function values, so the plot worked. Since `x` is
only suppose to take the `data_time_steps`, I also had to change what the
"Actual" plot is (it should be plotting `y`, which is what is trained
against). And the trucation of the sequences were off by one point in the
plot, so I fixed that as well.

Lastly, `forward()` was defined in a confusing way, which still worked, but
`input` was used as a global variable. It should be `input` that is passed to
the function, not `x`. (As was done for the plotting, but not in the
training).